### PR TITLE
Minor fixes to the VAE notebook

### DIFF
--- a/1-VAE.ipynb
+++ b/1-VAE.ipynb
@@ -105,7 +105,6 @@
     "        \"\"\"\n",
     "        super(BernoulliDecoder, self).__init__()\n",
     "        self.decoder_net = decoder_net\n",
-    "        self.std = nn.Parameter(torch.ones(28, 28)*0.5, requires_grad=True)\n",
     "\n",
     "    def forward(self, z):\n",
     "        \"\"\"\n",
@@ -255,12 +254,34 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "**Visualizing some samples from the dataset:** Let's take a look at how our binarized MNIST looks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torchvision.transforms.functional import to_pil_image\n",
+    "from torchvision.utils import make_grid\n",
+    "from IPython.display import display\n",
+    "\n",
+    "samples, labels = next(iter(mnist_train_loader))\n",
+    "image_pil = to_pil_image(make_grid(samples.view(-1, 1, 28, 28)))\n",
+    "display(image_pil)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "**Initialize the model and run the training loop**: Finally we initialize the model using a simple fully connected encoder and decoder networks and run the training loop."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -389,7 +410,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi Jes,

I just went through the notebook for the VAE example. I noticed that there's a `self.std` in the `BernoulliDecoder` that isn't used during training (I assume it stayed there after you changed from a `Normal` decoder to a `Bernoulli`).

I also added a visualization of the training set prior to training.

Cheers,
Miguel.